### PR TITLE
Fixed type issue causing gravity modal not to appear on merchant product selection

### DIFF
--- a/Welolo/client/src/components/TRANSACTION_FORM.js
+++ b/Welolo/client/src/components/TRANSACTION_FORM.js
@@ -8,11 +8,15 @@ class TRANSACTION_FORM extends Component {
     constructor(props) {
         super(props);
         selectedCost = props.data;
+        if (selectedCost == -1)
+        {
+          selectedCost = '';
+        }
         this.state = {
             message: {
                 recipient_name: '',
                 recipient: '',
-                sender_quantity: '',
+                sender_quantity: selectedCost,
                 body: ''
             },
             submitting: false,
@@ -163,7 +167,7 @@ class TRANSACTION_FORM extends Component {
     }
 
     render(){
-      if(selectedCost === -1)
+      if(selectedCost == '')
       {
         return (
             <div>
@@ -248,7 +252,7 @@ class TRANSACTION_FORM extends Component {
                           type="text"
                           name="sender_quantity"
                           id="sender_quantity"
-                          value={selectedCost}
+                          value={this.state.message.sender_quantity}
                           onChange={this.onHandleChange}
                           readOnly
                       />

--- a/Welolo/client/src/components/TRANSACTION_MOCK_MERCHANT.js
+++ b/Welolo/client/src/components/TRANSACTION_MOCK_MERCHANT.js
@@ -4,7 +4,7 @@ import TRANSACTION_FORM from './TRANSACTION_FORM.js';
 
 var Items = new Map();
 var selected = false;
-var data = -1;
+var data = "-1";
 
 class TRANSACTION_MOCK_MERCHANT extends Component {
     constructor(props) {

--- a/Welolo/server/index.js
+++ b/Welolo/server/index.js
@@ -134,14 +134,12 @@ app.get("/api/merchants", (req,res) => {
 
 app.get("/test", (req, res) => {
   res.json({ message: "This endpoint is working properly!" });
-  //TODO: Replace with our own functionality and change endpoint name
 });
 
 app.get("/payment_successful", (req, res) => {
   res.json({message: "success"});
 });
 
-//TODO: Add other endpoints here
 
 app.listen(PORT, () => {
   console.log(`Server listening on ${PORT}`);


### PR DESCRIPTION
Verification Steps:
- Select item from mock merchant
- Notice that the amount text box is locked and has the price of the selected item
- Fill out payment page with other acceptable information
- Submission of the form should cause the gravity modal to show up
- Refresh the page
- Select the skip this step button
- Notice that the amount text box is not locked and you can type in an amount
- Fill out the payment page with other acceptable information
- Submission of the form should cause the gravity modal to show up